### PR TITLE
Bkwd2: single backward pass combining computation of dloss_dx and dloss_dp

### DIFF
--- a/loss_and_optimizer_triton.py
+++ b/loss_and_optimizer_triton.py
@@ -52,6 +52,7 @@ def t_avg_cross_entropy_loss_bkwd2(y_labels, x_logits):
     # TODO XXX: code up derivative for torch.nanmean 
     jac_nanmean = -torch.func.jacrev(torch.nanmean)(elements_loss) 
     dloss_dx = torch.zeros_like(x_logits_2d) # bkwd for indexing
+    y_labels_1d = y_labels_1d.to(torch.int64) # HOTFIX. TODO XXX: Think whether we shouldn't pass ys in int64 instead?
     dloss_dx.scatter_(1, y_labels_1d.unsqueeze(1), jac_nanmean.unsqueeze(1))
     dloss_dx = t_log_softmax_bkwd2(dloss_dx, x_logits_2d)
     

--- a/model_triton.py
+++ b/model_triton.py
@@ -995,8 +995,13 @@ def t_gpt2_tlayers_bkwd2_p(dloss_dx, params, y, mask, indices, train=True, p_gen
     layers_dloss_dp = []
     for i, layer_params in reversed(list(enumerate(params[2:-1]))):
         y, layer_p_gen_aux = layers_inputs[i]
-        layers_dloss_dp.append(t_gpt2_tlayer_bkwd2_p(dloss_dx, layer_params, y, mask, train, layer_p_gen_aux))
-        dloss_dx = t_gpt2_tlayer_bkwd2_x(dloss_dx, layer_params, y, mask, train, layer_p_gen_aux)
+        # Use bkwd2 which combines dloss_dx and dloss_dp computations (for efficiency reasons)
+        # TODO XXX: do sanity check whether the results are exactly the same as for separate
+        # bkwd2_p and bkwd2_x
+        dloss_dx, layer_dloss_dp = t_gpt2_tlayer_bkwd2(dloss_dx, layer_params, y, mask, train, layer_p_gen_aux)
+        layers_dloss_dp.append(layer_dloss_dp)
+        #layers_dloss_dp.append(t_gpt2_tlayer_bkwd2_p(dloss_dx, layer_params, y, mask, train, layer_p_gen_aux))
+        #dloss_dx = t_gpt2_tlayer_bkwd2_x(dloss_dx, layer_params, y, mask, train, layer_p_gen_aux)
     layers_dloss_dp = list(reversed(layers_dloss_dp)) # TODO XXX: clean up list+ reversed combos
     
     # dropout + embed + pos_enc


### PR DESCRIPTION
Gives the substantial speedups: previously bkwd for SA had to be run 3 times per layer, now it's only run once.
TODO: double check whether the results of bkwd2 are the same as combined bkwd2_p and bkwd2_x together. Don't have good tests for that right now