### PR TITLE
Bkwd2: Improve memory usage

### DIFF
--- a/model_triton.py
+++ b/model_triton.py
@@ -770,8 +770,7 @@ def t_gpt2_tlayer_sublock1_bkwd2(dloss_dx, layer_params, y, mask, train=True, p_
     layernorm_dloss_dp = t_layernorm_bkwd2_p(dloss_dx, layer_params[:2], y_in)
     dloss_dx = t_layernorm_bkwd2_x(dloss_dx, layer_params[:2], y_in)
     # account for "y" in residual's "y + y_diff". TODO XXX: Does this reshape make sense?
-    jac_y = torch.eye(y.numel(), device=y.device).reshape(blck_dloss_dx.shape + blck_dloss_dx.shape)
-    dloss_dx = _vjp_in_2d(blck_dloss_dx, jac_y) + dloss_dx
+    dloss_dx = blck_dloss_dx + dloss_dx
     dloss_dp = layernorm_dloss_dp + tlayer_attn_dloss_dp
     
     return dloss_dx, dloss_dp
@@ -859,8 +858,7 @@ def t_gpt2_tlayer_sublock2_bkwd2(dloss_dx, layer_params, y, train=True, p_gen_au
     layernorm_dloss_dp = t_layernorm_bkwd2_p(dloss_dx, layer_params[:2], y_in)
     dloss_dx = t_layernorm_bkwd2_x(dloss_dx, layer_params[:2], y_in)
     # account for "y" in residual's "y + y_diff". TODO XXX: Does this reshape make sense?
-    jac_y = torch.eye(y.numel(), device=y.device).reshape(blck_dloss_dx.shape +blck_dloss_dx.shape)    
-    dloss_dx = _vjp_in_2d(blck_dloss_dx, jac_y) + dloss_dx
+    dloss_dx = blck_dloss_dx + dloss_dx
     dloss_dp = layernorm_dloss_dp + tlayer_ffn_dloss_dp
     
     return dloss_dx, dloss_dp

--- a/model_triton.py
+++ b/model_triton.py
@@ -129,8 +129,8 @@ def t_linear_bkwd_p(layer_params, x): # input: N x D
 def _vjp_in_2d(v, jac):
     outdim = jac.shape[len(v.shape):]
     # TODO: It's just vector times matrix, is there cleaner/more efficient way of doing this?
-    res = torch.matmul(v.reshape((1, -1)), jac.reshape((v.numel(), -1)))
-    return res.reshape(outdim)
+    res = torch.matmul(v.view((1, -1)), jac.reshape((v.numel(), -1)))
+    return res.view(outdim)
 
 # Do VJP row-wise. Useful when a row doesn't depend on other rows (saves space)
 def _vjp_in_2d_rowise(dloss_dx, rowise_jac): # dloss_dx: ... x IN_DIM, rowise_jac: BS x IN_DIM x OUT_DIM

--- a/model_triton.py
+++ b/model_triton.py
@@ -657,10 +657,8 @@ def t_layernorm_bkwd_x(layer_params, x):
 
 def t_layernorm_bkwd2_x(dloss_dx, layer_params, x):
     x_2d = x.reshape((-1, x.shape[-1]))
-    jac_x_2d = (layer_params[0] * normalized_x_bkwd(x_2d)).transpose(-3,-1)
-    jac = jac_x_2d.reshape(x.shape + x.shape)
-    
-    return _vjp_in_2d(dloss_dx, jac)
+    jac_x_2d = (layer_params[0] * normalized_x_bkwd_rowwise(x_2d)).transpose(-2,-1)
+    return _vjp_in_2d_rowise(dloss_dx, jac_x_2d)
     
 def t_gpt2_tlayer_sublock1_fwd(layer_params, y, mask, train=True, p_gen_aux=None):
     if not train:

--- a/model_triton.py
+++ b/model_triton.py
@@ -47,9 +47,8 @@ def t_log_softmax_bkwd2(dloss_dx, x_logits):
     logsums = torch.logsumexp(x_logits, axis=-1, keepdims=True)
     exp_logsums = torch.exp(logsums) # Q: is it going to be numerically stable?
 
-    # TODO XXX: I can either use expand here, or multiply directly with dloss_dx, so I save space
-    jac = torch.repeat_interleave(-torch.exp(x_logits)/exp_logsums, N, dim=0, output_size=x_logits.numel())
-    jac = jac.reshape(BS, N, N)
+    # TODO XXX: multiply dloss_dx inbefore expanding to higher dimension
+    jac = (-torch.exp(x_logits)/exp_logsums).unsqueeze(1).expand(BS, N, N)
     # As it's rowwise dependency of outputs on inputs, we don't use full jacobian.
     return dloss_dx + _vjp_in_2d_rowise(dloss_dx, jac)
 

--- a/model_triton.py
+++ b/model_triton.py
@@ -259,14 +259,17 @@ def t_softmax_attn_bkwd2(dloss_dx, q, k, mask, train, p_gen_aux=None):
     # TODO XXX: code up jacobian for this bmm
     from torch.func import jacrev
     qk_t_bmm_fn = lambda q, k: torch.matmul(q, k.transpose(-2, -1))/math.sqrt(D)
-    bmm_jac_k = jacrev(qk_t_bmm_fn, argnums=(1))(q, k)
+    # TODO XXX XXX: Investigate why the numerical differences between jacrev and vjp
+    #bmm_jac_k = jacrev(qk_t_bmm_fn, argnums=(1))(q, k)
+    (_, vjpfunc) = torch.func.vjp(qk_t_bmm_fn, q, k)
     #print(f'q/math.sqrt(D)', q/math.sqrt(D), '\nbmm_jac_k', bmm_jac_k) # the same values..
     # And: bmm_jac_q would have the same values as k/math.sqrt(D) (that fact is used below) 
     
     dloss_dx = t_log_softmax_bkwd2(dloss_dx, attn)
     dloss_dx = torch.where(torch.unsqueeze(mask,dim=1), dloss_dx, 0)
     dloss_dq = torch.matmul(dloss_dx, k/math.sqrt(D))
-    dloss_dk = _vjp_in_2d(dloss_dx, bmm_jac_k)
+    #dloss_dk = _vjp_in_2d(dloss_dx, bmm_jac_k)
+    dloss_dk = vjpfunc(dloss_dx)[1] # note, this also computes [0]...
     
     return dloss_dq, dloss_dk
 

--- a/model_triton.py
+++ b/model_triton.py
@@ -46,20 +46,23 @@ def t_log_softmax_bkwd2(dloss_dx, x_logits):
     x_logits = x_logits - torch.max(x_logits, axis=-1, keepdims=True)[0]
     logsums = torch.logsumexp(x_logits, axis=-1, keepdims=True)
     exp_logsums = torch.exp(logsums).unsqueeze(2) # Q: is it going to be numerically stable?
-    
-    # TODO XXX: can I use expand for the below line?
+        
+    # TODO XXX: I can either use expand here, or multiply directly with dloss_dx, so I save space
     jac = torch.repeat_interleave(-torch.exp(x_logits), N, dim=0, output_size=x_logits.numel())
     jac = jac.reshape(BS, N, N)/exp_logsums
-    jac_eye = torch.eye(N, device=x_logits.device).unsqueeze(0).expand(BS, N, N)
-    jac = jac_eye + jac
+    # As it's rowwise dependency of outputs on inputs, we don't use full jacobian.
+    return dloss_dx + _vjp_in_2d_rowise(dloss_dx, jac)
 
-    # Since it's only rowise dependency of outputs on inputs, we don't create full jacobian.
-    # Instead, we compute VJP in rowise fashion:
-    # jac_softmax = torch.block_diag(*jac.unbind(0)).reshape(indims+indims)
-    # dloss_dx = _vjp_in_2d(dloss_dx, jac_softmax)
-    dloss_dx = _vjp_in_2d_rowise(dloss_dx, jac)
+#     jac_eye = torch.eye(N, device=x_logits.device).unsqueeze(0).expand(BS, N, N)
+#     jac = jac_eye + jac
+
+#     # Since it's only rowise dependency of outputs on inputs, we don't create full jacobian.
+#     # Instead, we compute VJP in rowise fashion:
+#     # jac_softmax = torch.block_diag(*jac.unbind(0)).reshape(indims+indims)
+#     # dloss_dx = _vjp_in_2d(dloss_dx, jac_softmax)
+#     dloss_dx = _vjp_in_2d_rowise(dloss_dx, jac)
     
-    return dloss_dx
+#     return dloss_dx
 
 def t_embed_fwd(layer_params, x): # input: 1 x
     return layer_params[0][x] * math.sqrt(layer_params[0].shape[1]) # since layer_params[0] is vocab_size x emb_dim

--- a/model_triton.py
+++ b/model_triton.py
@@ -47,10 +47,9 @@ def t_log_softmax_bkwd2(dloss_dx, x_logits):
     logsums = torch.logsumexp(x_logits, axis=-1, keepdims=True)
     exp_logsums = torch.exp(logsums) # Q: is it going to be numerically stable?
 
-    # TODO XXX: multiply dloss_dx inbefore expanding to higher dimension
-    jac = (-torch.exp(x_logits)/exp_logsums).unsqueeze(1).expand(BS, N, N)
-    # As it's rowwise dependency of outputs on inputs, we don't use full jacobian.
-    return dloss_dx + _vjp_in_2d_rowise(dloss_dx, jac)
+    # TODO XXX: Add comments on maths why we can do elementwise VJP here
+    jac = -torch.exp(x_logits)/exp_logsums
+    return dloss_dx + dloss_dx.sum(-1, keepdim=True)*jac.reshape(dloss_dx.shape)
 
 #     jac_eye = torch.eye(N, device=x_logits.device).unsqueeze(0).expand(BS, N, N)
 #     jac = jac_eye + jac

--- a/model_triton.py
+++ b/model_triton.py
@@ -45,11 +45,11 @@ def t_log_softmax_bkwd2(dloss_dx, x_logits):
     
     x_logits = x_logits - torch.max(x_logits, axis=-1, keepdims=True)[0]
     logsums = torch.logsumexp(x_logits, axis=-1, keepdims=True)
-    exp_logsums = torch.exp(logsums).unsqueeze(2) # Q: is it going to be numerically stable?
-        
+    exp_logsums = torch.exp(logsums) # Q: is it going to be numerically stable?
+
     # TODO XXX: I can either use expand here, or multiply directly with dloss_dx, so I save space
-    jac = torch.repeat_interleave(-torch.exp(x_logits), N, dim=0, output_size=x_logits.numel())
-    jac = jac.reshape(BS, N, N)/exp_logsums
+    jac = torch.repeat_interleave(-torch.exp(x_logits)/exp_logsums, N, dim=0, output_size=x_logits.numel())
+    jac = jac.reshape(BS, N, N)
     # As it's rowwise dependency of outputs on inputs, we don't use full jacobian.
     return dloss_dx + _vjp_in_2d_rowise(dloss_dx, jac)
 

--- a/model_triton.py
+++ b/model_triton.py
@@ -49,9 +49,9 @@ def t_log_softmax_bkwd2(dloss_dx, x_logits):
     
     # TODO XXX: can I use expand for the below line?
     jac = torch.repeat_interleave(-torch.exp(x_logits), N, dim=0, output_size=x_logits.numel())
-    jac = jac.reshape(BS, N, N)
+    jac = jac.reshape(BS, N, N)/exp_logsums
     jac_eye = torch.eye(N, device=x_logits.device).unsqueeze(0).expand(BS, N, N)
-    jac = (exp_logsums * jac_eye + jac) / exp_logsums
+    jac = jac_eye + jac
 
     # Since it's only rowise dependency of outputs on inputs, we don't create full jacobian.
     # Instead, we compute VJP in rowise fashion:

--- a/model_triton.py
+++ b/model_triton.py
@@ -144,11 +144,10 @@ def _vjps_in_2d(v, jacs): # TODO XXX: reshape v once for all to speed up computa
 
 def t_linear_bkwd2_p(dloss_dx, layer_params, x): # input: N x D
     outdim = layer_params[1].shape[0]
-
     dloss_dp0 = t_proj_bkwd2_p(dloss_dx, layer_params[0], x)
-    jac2 = torch.eye(outdim, device=x.device).expand(x.shape[:-1] + (outdim, outdim))
+    dloss_dp1 = dloss_dx.view((-1, outdim)).sum(dim=0)
 
-    return dloss_dp0, _vjp_in_2d(dloss_dx, jac2)
+    return dloss_dp0, dloss_dp1
 
 def t_linear_bkwd_x(layer_params, x): # input: N x D
     return t_proj_bkwd_x(layer_params[0], x)

--- a/model_triton.py
+++ b/model_triton.py
@@ -142,10 +142,10 @@ def _vjps_in_2d(v, jacs): # TODO XXX: reshape v once for all to speed up computa
 def t_linear_bkwd2_p(dloss_dx, layer_params, x): # input: N x D
     outdim = layer_params[1].shape[0]
 
-    jac1 = t_proj_bkwd_p(layer_params[0], x)
+    dloss_dp0 = t_proj_bkwd2_p(dloss_dx, layer_params[0], x)
     jac2 = torch.eye(outdim, device=x.device).expand(x.shape[:-1] + (outdim, outdim))
-        
-    return _vjp_in_2d(dloss_dx, jac1), _vjp_in_2d(dloss_dx, jac2)
+
+    return dloss_dp0, _vjp_in_2d(dloss_dx, jac2)
 
 def t_linear_bkwd_x(layer_params, x): # input: N x D
     return t_proj_bkwd_x(layer_params[0], x)

--- a/model_triton.py
+++ b/model_triton.py
@@ -151,8 +151,7 @@ def t_linear_bkwd_x(layer_params, x): # input: N x D
     return t_proj_bkwd_x(layer_params[0], x)
 
 def t_linear_bkwd2_x(dloss_dx, layer_params, x): # input: N x D
-    # TODO XXX: call t_proj_bkwd2_x instead
-    return _vjp_in_2d(dloss_dx, t_proj_bkwd_x(layer_params[0], x))
+    return t_proj_bkwd2_x(dloss_dx, layer_params[0], x)
 
 def t_proj_fwd(layer_params, x): # input: seq_len x emb_dim
     return torch.matmul(x, torch.transpose(layer_params, -2, -1)) # since layer_params is ... x output_dim x emb_dim

--- a/model_triton.py
+++ b/model_triton.py
@@ -658,11 +658,9 @@ def normalized_x_bkwd_rowwise(x): # d [(x-x_mean)/x_std] / dx
     x_std = torch.std(x, axis=-1, keepdims = True)
      
     x_eye = torch.eye(N, device=x.device).expand(x.shape[0], N, N)
-    fdx_g = (x_eye - 1/N) *x_std.unsqueeze(-1)
-    f_gdx = torch.matmul((x-x_mean).unsqueeze(-1), std_bkwd(x).unsqueeze(-2)) 
-    g_pow2 = 1/torch.pow(x_std, 2)
-
-    jac = g_pow2.unsqueeze(-1) * (fdx_g  - f_gdx)
+    jac = (x_eye - 1/N) *x_std.unsqueeze(-1) # fdx_g
+    jac.sub_(torch.matmul((x-x_mean).unsqueeze(-1), std_bkwd(x).unsqueeze(-2))) # - f_gdx
+    jac.mul_(1/torch.pow(x_std, 2).unsqueeze(-1)) # * g_pow2
     return jac
 
 def t_layernorm_bkwd_x(layer_params, x):

--- a/train_gpt2_triton.py
+++ b/train_gpt2_triton.py
@@ -5,9 +5,9 @@
 ###############################################
 import argparse
 parser = argparse.ArgumentParser("train_gpt2_trition")
-parser.add_argument("backend", help="Either 'torchfunc_jit', 'debug_jacs' or 'triton'.", type=str)
+parser.add_argument("backend", help="Either 'torchfunc_jit' or 'triton'.", type=str)
 args = parser.parse_args()
-assert args.backend in ["torchfunc_jit", "debug_jacs", "triton"]
+assert args.backend in ["torchfunc_jit", "triton", "debug_jacs"]
 
 ###############################################
 ### DATASETs

--- a/train_gpt2_triton.py
+++ b/train_gpt2_triton.py
@@ -1,4 +1,15 @@
 ###############################################
+# This script can be used for training GPT2 model using
+# two different ml engines: torch.func+jit and triton.
+# See below for specifying correct ml engine
+###############################################
+import argparse
+parser = argparse.ArgumentParser("train_gpt2_trition")
+parser.add_argument("backend", help="Either 'torchfunc_jit', 'debug_jacs' or 'triton'.", type=str)
+args = parser.parse_args()
+assert args.backend in ["torchfunc_jit", "debug_jacs", "triton"]
+
+###############################################
 ### DATASETs
 ###############################################
 import datasets
@@ -40,6 +51,15 @@ print(f'Number of params: {count_num_params(params):_}')
 # ### Loss + Grads + Optimizers
 from loss_and_optimizer_triton import loss_train, loss_eval, grad_loss, acc_grad_loss, t_acc_grad_loss, t_acc_grad_loss2, init_adam_w, adam_w_in_place, grads_l2norm, grads_grps_l2norms # TODO XXX: add remaining
 # from loss_and_optimizer import loss_train, loss_eval, log_probs, grad_loss, predict, acc_grad_loss, init_adam_w, adam_w_in_place, grads_l2norm, grads_grps_l2norms
+
+# Choose the accumulation gradient loss function depending on the selected ML backend
+# TODO XXX: differentiate forward func too
+if args.backend =="torchfunc_jit":
+    acc_grad_loss_func =  acc_grad_loss
+elif args.backend =="debug_jacs":
+    acc_grad_loss_func = t_acc_grad_loss
+else:
+    acc_grad_loss_func = t_acc_grad_loss2
 
 # # Figure out non bias/gain params, as we only want to apply weight decay to those in AdamW
 # # Only 1D weights, which are initialized to 0s are bias/gain params (including bias of LayerNorm)
@@ -170,9 +190,7 @@ while True:
         # Training step
         # TODO: introduce update func, which does grad_loss and adam, and then call/jit that function instead of calling/jitting two separate ones
         # TODO XXX: int32 for y? we could use uint16 if it were available
-        #grads, (loss_val, acc, _) = t_acc_grad_loss2(grads, params, torch.tensor(y, dtype=torch.int32, device="cuda"), torch.tensor(y_mask, dtype=torch.bool, device="cuda"), torch.tensor(y_indices, dtype=torch.int, device="cuda"))
-        #grads, (loss_val, acc, _) = t_acc_grad_loss(grads, params, torch.tensor(y, dtype=torch.int32, device="cuda"), torch.tensor(y_mask, dtype=torch.bool, device="cuda"), torch.tensor(y_indices, dtype=torch.int, device="cuda"))
-        grads, (loss_val, acc, _) = acc_grad_loss(grads, params, torch.tensor(y, dtype=torch.int32, device="cuda"), torch.tensor(y_mask, dtype=torch.bool, device="cuda"), torch.tensor(y_indices, dtype=torch.int, device="cuda"))
+        grads, (loss_val, acc, _) = acc_grad_loss_func(grads, params, torch.tensor(y, dtype=torch.int32, device="cuda"), torch.tensor(y_mask, dtype=torch.bool, device="cuda"), torch.tensor(y_indices, dtype=torch.int, device="cuda"))
         #grads, (loss_val, acc) = grad_loss(params, jnp.array(x), jnp.array(y), key_iter)
 
         # LR Scheduler


### PR DESCRIPTION
Improving memory usage of Bkwd2 (i.e. vjp backward) mainly by:

- multiplying dloss_dx in Jacobian earlier in functions
- creating row-wise Jacobians instead of full Jacobians if an output row only depends on a single input row.

As a result, the current implementation of bkwd2 can:
- fit the same model + data as "torch.func+jit" does.
- runs 8 times slower than "torch.func+jit"

There are some TODOs:
- For Batched matrix multiplication, I rely on torch.func.vjpfunc instead of coding up bkwd myself. (Also, when I switched from torch.func.jacrev to torch.func.vjpfunc, I am getting slightly different numbers..)
- For layernorm's backward (see normalized_x_bkwd2_plus) , I got slightly inspired by llm.c. Need to investigate why memory usage is higher in my implementation (normalized_x_bkwd2): likely it has to do with creating BSxNxN tensors, which I shouldn't