### PR TITLE
Bkwd2 perf1: activation checkpointing

### DIFF
--- a/loss_and_optimizer_triton.py
+++ b/loss_and_optimizer_triton.py
@@ -13,7 +13,7 @@ import math
 import torch
 from torch.func import grad
 from model_torch_func import log_softmax, batched_forward_gpt2
-from model_triton import t_log_softmax_fwd, t_log_softmax_bkwd, t_log_softmax_bkwd2, t_batched_forward_gpt2, t_gpt2_forward, t_gpt2_bkwd_p, t_gpt2_bkwd2_p, _mult_jacs_in_2d
+from model_triton import t_log_softmax_fwd, t_log_softmax_bkwd, t_log_softmax_bkwd2, t_batched_forward_gpt2, t_gpt2_forward, t_gpt2_forward_with_acts, t_gpt2_bkwd_p, t_gpt2_bkwd2_p, t_gpt2_bkwd3_p, _mult_jacs_in_2d
 
 def avg_cross_entropy_loss(y_labels, x_logits):
     return _avg_cross_entropy_loss(log_softmax, y_labels, x_logits)
@@ -146,6 +146,20 @@ def t_loss_bkwd2(params, y, y_mask, y_indices, train, p_gen_aux=None):  # inputs
     
     return dloss_dx, (loss_val, acc, tokens_count/y_out.numel())
 
+def t_loss_bkwd3(params, y, y_mask, y_indices, train, p_gen_aux=None):  # inputs: BS x N    
+    y_in = y[:, :-1]
+    y_out = y[:, 1:]
+     
+    logits, acts = t_gpt2_forward_with_acts(params, y_in, y_mask, y_indices, train, p_gen_aux) 
+    
+    dloss_dx = t_avg_cross_entropy_loss_bkwd2(y_out, logits)
+    dloss_dx = t_gpt2_bkwd3_p(dloss_dx, acts, params, y_in, y_mask, y_indices, train, p_gen_aux)
+    
+    loss_val, tokens_count = t_avg_cross_entropy_loss(y_out, logits)
+    acc = accuracy(y_out, logits)
+    
+    return dloss_dx, (loss_val, acc, tokens_count/y_out.numel())
+
 # print(f'iter #{i} loss {loss_train(params, jnp.array(x[:1]), jnp.array(y[:1]), random.PRNGKey(0))[0] }')
 
 # with jax.disable_jit():
@@ -194,6 +208,11 @@ def t_acc_grad_loss(acc_grads, params, y, y_mask, y_indices):
 def t_acc_grad_loss2(acc_grads, params, y, y_mask, y_indices):
     p_gen_aux = sample_p_gen_aux(params)
     grad_loss_fn = partial(t_loss_bkwd2, train=True, p_gen_aux=p_gen_aux)
+    return _acc_grad_loss(grad_loss_fn, acc_grads, params, y, y_mask, y_indices)
+
+def t_acc_grad_loss3(acc_grads, params, y, y_mask, y_indices):
+    p_gen_aux = sample_p_gen_aux(params)
+    grad_loss_fn = partial(t_loss_bkwd3, train=True, p_gen_aux=p_gen_aux)
     return _acc_grad_loss(grad_loss_fn, acc_grads, params, y, y_mask, y_indices)
 
 

--- a/model_triton.py
+++ b/model_triton.py
@@ -992,7 +992,7 @@ def t_gpt2_tlayers_fwd3(params, y, mask, indices, train=True, p_gen_aux=None): #
     
     for i, layer_params in enumerate(params[2:-1]):
         layer_p_gen_aux = p_gen_aux[1+i*3:1+(i+1)*3]
-        acts.append((y,layer_p_gen_aux))
+        acts.append(y)
         y = t_gpt2_tlayer_fwd(layer_params, y, mask, train, layer_p_gen_aux)
     acts.append(y)
     y = t_layernorm_fwd(params[-1], y)
@@ -1107,7 +1107,8 @@ def t_gpt2_tlayers_bkwd3_p(dloss_dx, acts, params, y, mask, indices, train=True,
     
     indices = torch.arange(y.shape[1], device=y.device).unsqueeze(0).expand(*y.shape) # we ignore indices arg
     t_dropout_input = acts[0]
-    layers_inputs = acts[1:-1]
+    layers_p_gen_aux = [p_gen_aux[1+i*3:1+(i+1)*3] for i in range(len(params) - 3)]
+    layers_inputs = list(zip(acts[1:-1], layers_p_gen_aux))
     
     # Propoagate back    
     # layernorm


### PR DESCRIPTION
Reduce speed time by 20% from 4.08s/it to 3.24s/it.

Activations implementation follows this convention:
-  for forward pass: *op_fwd3 returns y output of the subgraph for op, and acts activations of the subgraph. Within op_fwd3, we create acts list by:
    - for the first op of the subgraph, store its acts only (as input y can be reused)
    - for the final op of the subgraph, store its acts only
    - for any op in between, store itss output and acts (it's recurrent definition: op can be subgraph itself)
- for backward : *op_bkwd3 takes additional elements acts representing activation of the subgraph

TODO:
t_tlayer_ffn_bkwd3 doesn't give any speed improvements due to reshape which has to be done on stored activations 