### PR TITLE
Bkwd3 perf: removing dependence on torch.func.vjpfunc for bmm

### DIFF
--- a/model_triton.py
+++ b/model_triton.py
@@ -7,7 +7,7 @@
 # *_bkwd_x: backward pass which computes Jacobian with respect to input
 # *_bkwd2: backward pass which computes VJPs with respect to input and parameters
 # *_bkwd3: backward pass which computes VJPs with respect to input and parameters (+ activation checkpointing)
-# (all backward passes are writen from first principle with exception of bkwd for BMM - TODO)
+# (all backward passes are writen from first principle with exception of bkwd for BMM in _bkwd_x, _bkwd_p and _bkwd2)
 
 ### PARAMS + MODEL
 DROPOUT_RATE = 0.1 # TODO: move it out, and pass as paramteter

--- a/train_gpt2_triton.py
+++ b/train_gpt2_triton.py
@@ -49,7 +49,7 @@ print(f'Vocabulary size: {model_vocab_size:_}')
 print(f'Number of params: {count_num_params(params):_}')
 
 # ### Loss + Grads + Optimizers
-from loss_and_optimizer_triton import loss_train, loss_eval, grad_loss, acc_grad_loss, t_acc_grad_loss, t_acc_grad_loss2, init_adam_w, adam_w_in_place, grads_l2norm, grads_grps_l2norms # TODO XXX: add remaining
+from loss_and_optimizer_triton import loss_train, loss_eval, grad_loss, acc_grad_loss, t_acc_grad_loss, t_acc_grad_loss2, t_acc_grad_loss3, init_adam_w, adam_w_in_place, grads_l2norm, grads_grps_l2norms # TODO XXX: add remaining
 # from loss_and_optimizer import loss_train, loss_eval, log_probs, grad_loss, predict, acc_grad_loss, init_adam_w, adam_w_in_place, grads_l2norm, grads_grps_l2norms
 
 # Choose the accumulation gradient loss function depending on the selected ML backend
@@ -59,7 +59,7 @@ if args.backend =="torchfunc_jit":
 elif args.backend =="debug_jacs":
     acc_grad_loss_func = t_acc_grad_loss
 else:
-    acc_grad_loss_func = t_acc_grad_loss2
+    acc_grad_loss_func = t_acc_grad_loss3
 
 # # Figure out non bias/gain params, as we only want to apply weight decay to those in AdamW
 # # Only 1D weights, which are initialized to 0s are bias/gain params (including bias of LayerNorm)


### PR DESCRIPTION
This gives some speedups (down to 2.99s/it), as it omits some reshapes 