### PR TITLE
Perf improvements to the (reverse) VJP backward pass + First version of Triton Kernels for most fundamental ops

### DIFF
--- a/loss_and_optimizer_triton.py
+++ b/loss_and_optimizer_triton.py
@@ -75,6 +75,34 @@ def t_avg_cross_entropy_loss_bkwd2(y_labels, x_logits):
     
     return dloss_dx.reshape(x_logits.shape)
 
+# Note, this doesn't follow the convention of _bkwd3 functions:
+# It's last op in the graph, thus we fused fwd and bkwd passes.
+# We return the results of both passes
+def t_avg_cross_entropy_loss_bkwd3(y_labels, x_logits):
+    dloss_dx_shape = x_logits.shape 
+    y_labels = y_labels.reshape((-1,))
+    x_logits = x_logits.reshape((y_labels.numel(), -1))
+    nonzero_count = torch.count_nonzero(y_labels)
+    
+    # Modified log_softmax_fn with swapped the order of ops (indexing<->subtraction),
+    # and computes values which are reused in propagation below
+    x_logits = x_logits - torch.max(x_logits, axis=-1, keepdims=True)[0]
+    x_logits_logsum = torch.logsumexp(x_logits, axis=-1, keepdims=True)
+    x_logits_indexed = x_logits[(torch.arange(y_labels.numel()), y_labels)]
+    elements_loss = torch.where(y_labels != 0, x_logits_indexed - x_logits_logsum, float('nan'))
+    loss = -torch.nanmean(elements_loss) 
+    
+    # propagate back
+    jac_nanmean = torch.where(y_labels != 0, -1/nonzero_count, 0)
+    y_labels = y_labels.to(torch.int64) # TODO XXX: shouldn't we pass y_labels in int64 already?
+    x_logits_exp_logsum = torch.exp(x_logits_logsum) # Q: is it going to be numerically stable?
+    log_softmax_jac = -torch.exp(x_logits)/x_logits_exp_logsum    
+    # TODO T: below I still need to create another array, can't src just be "1"?
+    log_softmax_jac.scatter_add_(1, y_labels.unsqueeze(1), torch.ones_like(log_softmax_jac)) # bkwd for indexing
+    dloss_dx = jac_nanmean.unsqueeze(1) * log_softmax_jac
+    
+    return loss, nonzero_count, dloss_dx.reshape(dloss_dx_shape)
+
 def accuracy(y_labels, x_logits):
     return torch.nanmean(torch.where(y_labels!=0, y_labels == torch.argmax(x_logits, axis=-1), float('nan')))
 
@@ -152,10 +180,8 @@ def t_loss_bkwd3(params, y, y_mask, y_indices, train, p_gen_aux=None):  # inputs
      
     logits, acts = t_gpt2_forward_with_acts(params, y_in, y_mask, y_indices, train, p_gen_aux) 
     
-    dloss_dx = t_avg_cross_entropy_loss_bkwd2(y_out, logits)
+    loss_val, tokens_count, dloss_dx = t_avg_cross_entropy_loss_bkwd3(y_out, logits)
     dloss_dx = t_gpt2_bkwd3_p(dloss_dx, acts, params, y_in, y_mask, y_indices, train, p_gen_aux)
-    
-    loss_val, tokens_count = t_avg_cross_entropy_loss(y_out, logits)
     acc = accuracy(y_out, logits)
     
     return dloss_dx, (loss_val, acc, tokens_count/y_out.numel())

--- a/loss_and_optimizer_triton.py
+++ b/loss_and_optimizer_triton.py
@@ -76,7 +76,7 @@ def t_avg_cross_entropy_loss_bkwd2(y_labels, x_logits):
     return dloss_dx.reshape(x_logits.shape)
 
 # Note, this doesn't follow the convention of _bkwd3 functions:
-# It's last op in the graph, thus we fused fwd and bkwd passes.
+# It's the last op of the graph, thus we fuse fwd and bkwd passes.
 # We return the results of both passes
 def t_avg_cross_entropy_loss_bkwd3(y_labels, x_logits):
     dloss_dx_shape = x_logits.shape 

--- a/model_triton.py
+++ b/model_triton.py
@@ -287,31 +287,35 @@ def t_gelu_bkwd2_t(dloss_dx: torch.Tensor, x: torch.Tensor):
 def t_linear_fwd(layer_params, x): # input: seq_len x emb_dim
     return torch.matmul(x, torch.transpose(layer_params[0], 0, 1)) + layer_params[1][None, :] # since layer_params[0] is output_dim x emb_dim, layer_params[1] is output_dim
 
-# WIP: for now, only supports: if m,n<BLOCK_SIZE AND K%BLOCK_SIZE=0
+# WIP: perf is lagging behidn torch's 
 @triton.jit
 def t_matmul_k(a_ptr, b_ptr, output_ptr,
                 a_row_stride, a_col_stride,
                 b_row_stride, b_col_stride,
                 output_row_stride, output_col_stride,
                 n, m, k,
-                BLOCK_SIZE: tl.constexpr,               
+                BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,               
                 ):
-    pid = tl.program_id(0)
-    num_programs = tl.num_programs(0)
-    offsets = tl.arange(0, BLOCK_SIZE) 
+    n_pid = tl.program_id(0)
+    m_pid = tl.program_id(1)
     
-    # TODO T: add modulo N, and modulo M ops for offsets. Why do I need them?
+    offsets = tl.arange(0, BLOCK_SIZE_K)     
+    n_offsets = n_pid * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    m_offsets = m_pid * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    # TODO T: Do I need modulo n, modulo m operations?    
+    n_offsets_mod = n_offsets %n
+    m_offsets_mod = m_offsets %m
     
-    acc = tl.zeros((BLOCK_SIZE, BLOCK_SIZE), dtype=tl.float32)
-    for i in range(0, tl.cdiv(k, BLOCK_SIZE)):
-        step_offsets = i*BLOCK_SIZE + offsets
-        a_blck_ptr = a_ptr + offsets[:,None] * a_row_stride + step_offsets[None, :] * a_col_stride
-        a_blck = tl.load(a_blck_ptr, mask=step_offsets[None, :] < k, other=0.0) 
-        b_blck_ptr = b_ptr + step_offsets[:,None] * b_row_stride + offsets[None, :] * b_col_stride
-        b_blck = tl.load(b_blck_ptr, mask=step_offsets[:, None] < k, other=0.0)
+    acc = tl.zeros((BLOCK_SIZE_N, BLOCK_SIZE_M), dtype=tl.float32)
+    for i in range(0, tl.cdiv(k, BLOCK_SIZE_K)):
+        k_step_offsets = i*BLOCK_SIZE_K + offsets
+        a_blck_ptr = a_ptr + n_offsets_mod[:,None] * a_row_stride + k_step_offsets[None, :] * a_col_stride
+        a_blck = tl.load(a_blck_ptr, mask=k_step_offsets[None, :] < k, other=0.0) 
+        b_blck_ptr = b_ptr + k_step_offsets[:,None] * b_row_stride + m_offsets_mod[None, :] * b_col_stride
+        b_blck = tl.load(b_blck_ptr, mask=k_step_offsets[:, None] < k, other=0.0)
         acc = tl.dot(a_blck, b_blck, acc)
-    output_blck_ptr = output_ptr + offsets[:,None] * output_row_stride + offsets[None, :] * output_col_stride
-    output_mask = (offsets[:,None] <n) & (offsets[None, :]<m)
+    output_blck_ptr = output_ptr + n_offsets[:,None] * output_row_stride + m_offsets[None, :] * output_col_stride
+    output_mask = (n_offsets[:,None] <n) & (m_offsets[None, :]<m)
     tl.store(output_blck_ptr, acc, mask=output_mask)
     
 def t_linear_bkwd_p(layer_params, x): # input: N x D

--- a/model_triton.py
+++ b/model_triton.py
@@ -1,4 +1,4 @@
-# WORK IN PROGRESS: currently, coding up Triton kernals
+# WORK IN PROGRESS: currently, coding up more efficient Triton kernals
 
 # Convention for function names:
 # *_fwd: forward pass
@@ -7,6 +7,7 @@
 # *_bkwd_x: backward pass which computes Jacobian with respect to input
 # *_bkwd2: backward pass which computes VJPs with respect to input and parameters
 # *_bkwd3: backward pass which computes VJPs with respect to input and parameters (+ activation checkpointing)
+# *_t: version of the above methods, but written in Triton (basic version of kernels for now)
 # (all backward passes are writen from first principle with exception of bkwd for BMM in _bkwd_x, _bkwd_p and _bkwd2)
 
 ### PARAMS + MODEL

--- a/model_triton.py
+++ b/model_triton.py
@@ -287,6 +287,29 @@ def t_gelu_bkwd2_t(dloss_dx: torch.Tensor, x: torch.Tensor):
 def t_linear_fwd(layer_params, x): # input: seq_len x emb_dim
     return torch.matmul(x, torch.transpose(layer_params[0], 0, 1)) + layer_params[1][None, :] # since layer_params[0] is output_dim x emb_dim, layer_params[1] is output_dim
 
+# WIP: only supports if m,n,k<BLOCK_SIZE for now
+@triton.jit
+def t_matmul_k(a_ptr, b_ptr, output_ptr,
+                a_row_stride, a_col_stride,
+                b_row_stride, b_col_stride,
+                output_row_stride, output_col_stride,
+                n, m, k,
+                BLOCK_SIZE: tl.constexpr,               
+                ):
+    pid = tl.program_id(0)
+    num_programs = tl.num_programs(0)
+    offsets = tl.arange(0, BLOCK_SIZE)   
+    a_blck_ptr = a_ptr + (pid + offsets)[:,None] * a_row_stride + offsets[None, :] * a_col_stride
+    a_blck = tl.load(a_blck_ptr, mask=offsets[None, :] < k, other=0.0)    
+    
+    acc = tl.zeros((BLOCK_SIZE, BLOCK_SIZE), dtype=tl.float32)
+    for _ in range(1): #TODO T: expand to the case when k>BLOCK_SIZE + move a_block inside loop
+        b_blck_ptr = b_ptr + offsets[:,None] * b_row_stride + (0 + offsets[None, :])
+        b_blck = tl.load(b_blck_ptr, mask=offsets[:, None] < k, other=0.0)
+        acc = tl.dot(a_blck, b_blck, acc)
+    output_blck_ptr = output_ptr + (pid + offsets)[:,None] * output_row_stride + offsets[None, :] * output_col_stride
+    tl.store(output_blck_ptr, acc)
+    
 def t_linear_bkwd_p(layer_params, x): # input: N x D
     outdim = layer_params[1].shape[0]
 

--- a/model_triton.py
+++ b/model_triton.py
@@ -1178,6 +1178,77 @@ def t_layernorm_bkwd2_x(dloss_dx, layer_params, x):
     #return normalized_x_bkwd2(dloss_dx * layer_params[0], x_2d)
     dloss_dx_2d = dloss_dx.reshape((-1, dloss_dx.shape[-1]))
     return normalized_x_bkwd2_plus(dloss_dx_2d * layer_params[0], x_2d).reshape(dloss_dx.shape)
+
+# Note that the kernel assumes that n_cols < BLOCK_SIZE
+# TODO T: investigate numerical differences from torch.func implementation
+@triton.jit
+def t_layernorm_bkwd2_x_k(dloss_dx_ptr,
+                    param1_ptr,
+                    x_ptr,
+                    output_ptr,
+                    dloss_dx_stride,
+                    x_row_stride,
+                    output_row_stride,
+                    n_rows,
+                    n_cols,
+                    BLOCK_SIZE: tl.constexpr,
+                    num_stages: tl.constexpr,
+                    ):
+    row_start = tl.program_id(0)
+    row_step = tl.num_programs(0)
+    
+    # Load shared params
+    # TODO T: I think triton will load them once into shared memory -> confirm
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_cols
+    param1 = tl.load(param1_ptr + offsets, mask=mask, other=0.0)  
+        
+    for row_idx in tl.range(row_start, n_rows, row_step, num_stages):
+        dloss_dx_row_start_ptr = dloss_dx_ptr + row_idx * dloss_dx_stride
+        dloss_dx = tl.load(dloss_dx_row_start_ptr + offsets, mask=mask, other=0.0)
+        dloss_dx = dloss_dx * param1
+        x_row_start_ptr = x_ptr + row_idx * x_row_stride    
+        x = tl.load(x_row_start_ptr + offsets, mask=mask, other=0.0)
+        
+        # compute mean and std for x
+        x_sum = tl.sum(x, axis=0)
+        x_mu = x_sum/ n_cols
+        x_minus_mu = x - x_mu
+        x_minus_mu2 = x_minus_mu * x_minus_mu
+        x_minus_mu2_sum = tl.sum(x_minus_mu2, axis=0)
+        x_sigma2 = x_minus_mu2_sum / (n_cols-1)
+        x_sigma = tl.sqrt_rn(x_sigma2)
+        
+        # normalize x
+        x_norm = x_minus_mu/x_sigma    
+        
+        # bkwd quantities
+        dloss_dx_sum = tl.sum(dloss_dx, axis=0)
+        dloss_dx_mu = dloss_dx_sum/n_cols
+        dloss_dx_x_norm = dloss_dx * x_norm
+        dloss_dx_x_norm_sum = tl.sum(dloss_dx_x_norm, axis=0)
+        dloss_dx_x_norm_mu = dloss_dx_x_norm_sum/n_cols
+        
+        n_adj = n_cols/(n_cols-1) # adjust for estimated vs calculated sigma
+        output = dloss_dx - dloss_dx_mu - x_norm * dloss_dx_x_norm_mu * n_adj
+        output_row_start_ptr = output_ptr + row_idx * output_row_stride
+        tl.store(output_row_start_ptr + offsets, output, mask=mask)
+    
+def t_layernorm_bkwd2_x_t(dloss_dx:torch.Tensor, layer_params: torch.Tensor, x: torch.Tensor):
+    # TODO T: without this reshape, this func is 2times faster?
+    dloss_dx_2d = dloss_dx.reshape((-1, dloss_dx.shape[-1]))
+    x_2d = x.reshape((-1, x.shape[-1])) 
+    n_rows, n_cols = x_2d.shape
+    BLOCK_SIZE = triton.next_power_of_2(n_cols) 
+    output = torch.empty_like(x_2d)
+    # TODO T: The below numbers were tuned for A10 by choosing num_warps=8
+    num_warps = 8
+    num_stages = 2
+    num_programs = min(n_rows, 480) 
+    t_layernorm_bkwd2_x_k[(num_programs,)](dloss_dx_2d, layer_params[0], x_2d, output, 
+                                       dloss_dx_2d.stride(0), x_2d.stride(0), output.stride(0), n_rows, n_cols, 
+                                       BLOCK_SIZE=BLOCK_SIZE, num_warps=num_warps, num_stages=num_stages)
+    return output.reshape(dloss_dx.shape)
     
 def t_gpt2_tlayer_sublock1_fwd(layer_params, y, mask, train=True, p_gen_aux=None):
     if not train:

--- a/model_triton.py
+++ b/model_triton.py
@@ -312,8 +312,13 @@ def t_matmul_k(a_ptr, b_ptr, output_ptr,
     n_pid = orig_n_pid
     m_pid = orig_m_pid 
     # TODO T: Below, tiling blocks doesn't give expected speedup improvement below. Investigate
-    #n_pid = orig_n_pid % GROUP_SIZE_M + orig_m_pid // GROUP_SIZE_M
-    #m_pid = orig_n_pid // GROUP_SIZE_M + orig_m_pid % GROUP_SIZE_M
+    # TODO T: simplify the grp_id calculations. Expand if m_programs are not divisable by GROUP_SIZE_M
+    # TODO T: handle if m_programs < GROUP_SIZE_M
+    # m_groups = m_programs // GROUP_SIZE_M # assumes m_programs is divisable by GROUP_SIZE_M for now
+    # n_grp_id = orig_n_pid % (n_programs//m_groups) # assumes n_programs is divisable by m_groups for now 
+    # m_grp_id = (orig_n_pid * m_groups)//n_programs
+    # n_pid =  n_grp_id * m_groups + orig_m_pid // GROUP_SIZE_M
+    # m_pid =  m_grp_id * GROUP_SIZE_M + orig_m_pid % GROUP_SIZE_M
     
     offsets = tl.arange(0, BLOCK_SIZE_K)     
     n_offsets = n_pid * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)

--- a/model_triton.py
+++ b/model_triton.py
@@ -340,7 +340,7 @@ def t_matmul_t(a:torch.Tensor, b: torch.Tensor):
     assert K==K2
     assert a.is_contiguous(), "Matrix A must be contiguous" # TODO T: why do I need contiguous a?
     output = torch.empty((N, M), device=a.device)
-    grid = lambda META: (triton.cdiv(N, META['BLOCK_SIZE_N'] * triton.cdiv(M, META['BLOCK_SIZE_M'])), )
+    grid = lambda META: (triton.cdiv(N, META['BLOCK_SIZE_N']) * triton.cdiv(M, META['BLOCK_SIZE_M']), )
     t_matmul_k[grid](
         a, b, output, 
         a.stride(0), a.stride(1), b.stride(0), b.stride(1), output.stride(0), output.stride(1), 

--- a/model_triton.py
+++ b/model_triton.py
@@ -1096,17 +1096,17 @@ def t_layernorm_bkwd_p(layer_params, x):
     jac2 = torch.eye(outdim, device=x.device).expand(x_indims[:-1] + (outdim, outdim))
     return jac1 *jac1_aux, jac2
 
+# TODO XXX XXX: we can get rid of these big Jacobians here..
 def t_layernorm_bkwd2_p(dloss_dx, layer_params, x):
     x_indims = x.shape
-    N = x.shape[-1]
-    outdim=layer_params[1].shape[0]
+    N = x_indims[-1]
     
     
     x_mean = torch.mean(x, axis=-1, keepdims=True)
     x_std = torch.std(x, axis=-1, keepdims=True)
     jac1 = ((x-x_mean)/x_std).unsqueeze(-1).expand(x_indims + (N, ))
     jac1_aux = torch.eye(N, device=x.device) # just used for reshaping
-    jac2 = torch.eye(outdim, device=x.device).expand(x_indims[:-1] + (outdim, outdim))
+    jac2 = torch.eye(N, device=x.device).expand(x_indims[:-1] + (N, N))
     
     return _vjp_in_2d(dloss_dx, jac1 *jac1_aux), _vjp_in_2d(dloss_dx, jac2)
 

--- a/model_triton.py
+++ b/model_triton.py
@@ -27,6 +27,44 @@ def t_log_softmax_fwd(x_logits): # compute log_softmax from logits over the last
     x_logits = x_logits - torch.max(x_logits, axis=-1, keepdims=True)[0] # as it returns (maxs, indices)
     return x_logits - torch.logsumexp(x_logits, axis=-1, keepdims=True)
 
+@triton.jit
+def t_log_softmax_fwd_k(x_ptr,
+                    output_ptr,
+                    input_row_stride,
+                    output_row_stride,
+                    n_rows,
+                    n_cols,
+                    BLOCK_SIZE: tl.constexpr,
+                    # NOTE: `constexpr` so it can be used as a shape value. <- TODO T: think about it
+                    ):
+    row_start = tl.program_id(0)
+    row_step = tl.num_programs(0)
+    for row_idx in tl.range(row_start, n_rows, row_step): # TODO T: it fails if I add stages??
+        x_row_start_ptr = x_ptr + row_idx * input_row_stride
+        offsets = tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_cols
+        x = tl.load(x_row_start_ptr + offsets, mask=mask, other=-1e9)
+        x_minus_max = x - tl.max(x, axis=0)
+        log_denominator = tl.exp(x_minus_max)
+        log_denominator = tl.sum(log_denominator, axis=0)
+        log_denominator = tl.log(log_denominator)
+        output = x_minus_max - log_denominator
+        # In case I want to change semantic to t_softmax_fwd_k:
+        # nominator = tl.exp(x_minus_max)
+        # denominator = tl.sum(nominator, axis=0)
+        # output = nominator/denominator        
+        output_row_start_ptr = output_ptr + row_idx * output_row_stride
+        tl.store(output_row_start_ptr + offsets, output, mask=mask)
+    
+def t_log_softmax_fwd_t(x: torch.Tensor):
+    x_2d = x.reshape((-1, x.shape[-1])) # TODO T: without this reshape, this func is 2times faster
+    n_rows, n_cols = x_2d.shape
+    BLOCK_SIZE = triton.next_power_of_2(n_cols) 
+    output = torch.empty_like(x_2d)
+    num_programs = min(n_rows, 2048) # TODO T: compute correct number based on occupancy/SM
+    t_log_softmax_fwd_k[(num_programs,)](x_2d, output, x_2d.stride(0), output.stride(0), n_rows, n_cols, BLOCK_SIZE=BLOCK_SIZE)
+    return output.reshape(x.shape)
+
 def t_log_softmax_bkwd(x_logits):
     indims = x_logits.shape
     x_logits = x_logits.reshape((-1, x_logits.shape[-1]))

--- a/setup.sh
+++ b/setup.sh
@@ -22,3 +22,8 @@ git config --global --add safe.directory /efs/notebooks/mkukla/pre-tjax
 
 pip install wandb
 wandb login
+
+
+# Corect packages of torch/triton for running torchfunc_jit/triton version
+# pip install torch==2.5.1
+# pip install triton==3.1.0

--- a/train_gpt2_jax.py
+++ b/train_gpt2_jax.py
@@ -158,7 +158,7 @@ print(f'Number of params: {count_num_params(params):_}')
 num_steps = num_steps_multidevice * gradient_accumulations_steps
 while True:
     #for _, batch in tqdm(enumerate(itertools.islice(get_batched_examples(ds, batch_size, seq_len, START_TOK, END_TOK, skip_n_rows = ds_train_rows_read), num_steps)), initial=i, total=num_steps, smoothing=0):
-    for _, batch in tqdm(enumerate(itertools.islice(get_batched_examples_packed(ds, batch_size, seq_len, START_TOK, END_TOK, pack_frac=0.75, skip_n_rows = ds_train_rows_read), num_steps)), initial=i, total=num_steps, smoothing=0):
+    for _, batch in tqdm(enumerate(itertools.islice(get_batched_examples_packed(ds, batch_size, seq_len, START_TOK, END_TOK, pack_frac=0.75, skip_n_rows = ds_train_rows_read), num_steps)), initial=i, total=num_steps, smoothing=0.3):
         _, y, _, y_mask, _, _, y_indices = batch
         # Training step
         # TODO: introduce update func, which does grad_loss and adam, and then call/jit that function instead of calling/jitting two separate ones

--- a/train_gpt2_triton.py
+++ b/train_gpt2_triton.py
@@ -184,7 +184,7 @@ print(f'Number of params: {count_num_params(params):_}')
 num_steps = num_steps_multidevice * gradient_accumulations_steps
 while True:
     #for _, batch in tqdm(enumerate(itertools.islice(get_batched_examples(ds, batch_size, seq_len, START_TOK, END_TOK, skip_n_rows = ds_train_rows_read), num_steps)), initial=i, total=num_steps, smoothing=0):
-    for _, batch in tqdm(enumerate(itertools.islice(get_batched_examples_packed(ds, batch_size, seq_len, START_TOK, END_TOK, pack_frac=0.75, skip_n_rows = ds_train_rows_read), num_steps)), initial=i, total=num_steps, smoothing=0):
+    for _, batch in tqdm(enumerate(itertools.islice(get_batched_examples_packed(ds, batch_size, seq_len, START_TOK, END_TOK, pack_frac=0.75, skip_n_rows = ds_train_rows_read), num_steps)), initial=i, total=num_steps, smoothing=1):
         _, y, _, y_mask, _, _, y_indices = batch
         # Training step
         # TODO: introduce update func, which does grad_loss and adam, and then call/jit that function instead of calling/jitting two separate ones

--- a/train_gpt2_triton.py
+++ b/train_gpt2_triton.py
@@ -184,7 +184,7 @@ print(f'Number of params: {count_num_params(params):_}')
 num_steps = num_steps_multidevice * gradient_accumulations_steps
 while True:
     #for _, batch in tqdm(enumerate(itertools.islice(get_batched_examples(ds, batch_size, seq_len, START_TOK, END_TOK, skip_n_rows = ds_train_rows_read), num_steps)), initial=i, total=num_steps, smoothing=0):
-    for _, batch in tqdm(enumerate(itertools.islice(get_batched_examples_packed(ds, batch_size, seq_len, START_TOK, END_TOK, pack_frac=0.75, skip_n_rows = ds_train_rows_read), num_steps)), initial=i, total=num_steps, smoothing=1):
+    for _, batch in tqdm(enumerate(itertools.islice(get_batched_examples_packed(ds, batch_size, seq_len, START_TOK, END_TOK, pack_frac=0.75, skip_n_rows = ds_train_rows_read), num_steps)), initial=i, total=num_steps, smoothing=0.3):
         _, y, _, y_mask, _, _, y_indices = batch
         # Training step
         # TODO: introduce update func, which does grad_loss and adam, and then call/jit that function instead of calling/jitting two separate ones


### PR DESCRIPTION
- The perf improvements to (reverse) VJP backward pass:
  - fix for `t_layernorm_bkwd2_p`, so no expensive Jacobians are created: brings speed to the around half of `torchfunc+jit` one (i.e. around `2it/s` vs `4it/s`)
  - create `t_avg_cross_entropy_loss_bkwd3`, which fuses (in PyTroch) forward and backward pass for this op 
  - efficient `t_indexing_bkwd2`, which uses `scatter_add_`
- First version of Triton Kernels for most ops (all ops except attention + unfinished matmul). The convention for these methods is `*_t`. It's forward and backward passwes. The kernels are not plugged yet, but, if plugged, the speed goes up to `2.5it/s`